### PR TITLE
Get rid of sun.security for tmp file creation

### DIFF
--- a/src/main/java/cmd/InteractiveAlignment.java
+++ b/src/main/java/cmd/InteractiveAlignment.java
@@ -4,7 +4,8 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.security.AccessController;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -41,7 +42,6 @@ import net.imglib2.util.Pair;
 import net.imglib2.util.ValuePair;
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
-import sun.security.action.GetPropertyAction;
 import util.Threads;
 
 // -i /Users/preibischs/Documents/BIMSB/Publications/imglib2-st/slide-seq/raw/slide-seq.n5 -d1 Puck_180531_22.n5 -d2 Puck_180531_23.n5 -n 4 -sk 2
@@ -138,13 +138,11 @@ public class InteractiveAlignment implements Callable<Void> {
 		//
 		// assemble genes to test
 		//
-		System.out.println( "Assembling inital genes for alignment (" + numGenes + " genes)... ");
+		System.out.println("Assembling initial genes for alignment (" + numGenes + " genes)...");
 
-		final File tmpdir = new File(AccessController.doPrivileged(new GetPropertyAction("java.io.tmpdir")));
-		final File tmp =
-				new File(
-						tmpdir.getAbsolutePath(),
-						inputPath.hashCode() + "_" + dataset1.hashCode() + "_" + dataset2.hashCode() + ".stim.tmp" );
+		final Path tmpDir = Files.createTempDirectory("stim");
+		final String tmpFileName = inputPath.hashCode() + "_" + dataset1.hashCode() + "_" + dataset2.hashCode() + ".stim.tmp";
+		final File tmp = new File(tmpDir.toString(), tmpFileName);
 		final List< Pair< String, Double > > allGenes = new ArrayList<>();
 
 		if ( tmp.exists() )


### PR DESCRIPTION
Since `mvn install` wouldn't work for me, I replaced the tmp file creation that used `sun.security` with the officially supported way using `java.nio.file`.

@StephanPreibisch, was there any particular reason to use `sun.security` in the first place? In particular, does the current implementation work for you?

The `sun.*` packages are internal to oracle jdk builds and are not present, e.g., on the Azul jdk, which is the one available on conda. The [documentation](https://www.oracle.com/java/technologies/faq-sun-packages.html) says:
> A Java program that directly calls into sun.* packages is not guaranteed to work on all Java-compatible platforms. In fact, such a program is not guaranteed to work even in future versions on the same platform.