### PR TITLE
fixed cmdline pairwise alignment not working

### DIFF
--- a/src/main/java/cmd/PairwiseSectionAligner.java
+++ b/src/main/java/cmd/PairwiseSectionAligner.java
@@ -228,10 +228,10 @@ public class PairwiseSectionAligner implements Callable<Void> {
 				// start alignment
 				//
 				final SIFTParam p = new SIFTParam();
-				p.setIntrinsicParameters( SIFTPreset.VERYTHOROUGH );
 				// TODO: set all parameters
 				final List< FilterFactory< DoubleType, DoubleType > > filterFactories = null;
-				//p.setDatasetParameters(maxEpsilon, scale, 1024, filterFactories, Rendering.Gauss, smoothnessFactor, 0.0, 1.0); 
+				p.setDatasetParameters(maxEpsilon, scale, 1024, filterFactories, Rendering.Gauss, renderingFactor, 0.0, 1.0); 
+				p.setIntrinsicParameters( SIFTPreset.VERYTHOROUGH );
 				p.minInliersGene = minNumInliersGene;
 				p.minInliersTotal = minNumInliers;
 


### PR DESCRIPTION
In current master, pairwise alignment with `st-align-pairs` does not work (inliers are never found).

This might have to do with the initialization of `SIFTParam`, which has some critical values like `scale` (and others) set to `Double.NaN`. afaik, these were never set.