### PR TITLE
cmdline refactor

### DIFF
--- a/src/main/java/cmd/AddPairwiseMatch.java
+++ b/src/main/java/cmd/AddPairwiseMatch.java
@@ -48,8 +48,8 @@ public class AddPairwiseMatch implements Callable<Void> {
 	@Option(names = {"-s", "--scale"}, required = false, description = "scaling factor rendering the coordinates into images, which is highly sample-dependent (default: 0.05 for slideseq data)")
 	private double scale = 0.05;
 
-	@Option(names = {"-sf", "--smoothnessFactor"}, required = false, description = "factor for the sigma of the gaussian used for rendering, corresponds to smoothness, e.g -sf 2.0 (default: 4.0)")
-	private double smoothnessFactor = 4.0;
+	@Option(names = {"-rf", "--renderingFactor"}, required = false, description = "factor for the amount of filtering or radius used for rendering, corresponds to smoothness for Gauss, e.g -rf 2.0 (default: 1.0)")
+	private double smoothnessFactor = 1.0;
 
 	@Option(names = {"-l", "--lambda"}, required = false, description = "for rendering we use a 2D interpolated model (affine/rigid). The number defines the degree of rigidity, fully affine is 0.0, fully rigid is 1.0 (default: 1.0 - rigid)")
 	private double lambda = 1.0;

--- a/src/main/java/cmd/GlobalOpt.java
+++ b/src/main/java/cmd/GlobalOpt.java
@@ -71,7 +71,7 @@ public class GlobalOpt implements Callable<Void> {
 	@Option(names = {"--minIterationsICP"}, required = false, description = "minimum number of iterations during ICP (default: 500)")
 	private int minIterationsICP = 500;
 
-	@Option(names = {"-sf", "--smoothnessFactor"}, required = false, description = "FOR DISPLAY ONLY: factor for the sigma of the gaussian used for rendering, corresponds to smoothness, e.g -sf 2.0 (default: 1.5)")
+	@Option(names = {"-rf", "--renderingFactor"}, required = false, description = "FOR DISPLAY ONLY: factor for the amount of filtering or radius used for rendering, corresponds to smoothness for Gauss, e.g -rf 2.0 (default: 4.0)")
 	private double smoothnessFactor = AlignTools.defaultSmoothnessFactor;
 
 	@Option(names = {"-g", "--gene"}, required = false, description = "FOR DISPLAY ONLY: gene to display, e.g. -g Calm2")

--- a/src/main/java/cmd/InteractiveAlignment.java
+++ b/src/main/java/cmd/InteractiveAlignment.java
@@ -41,26 +41,26 @@ import picocli.CommandLine;
 import picocli.CommandLine.Option;
 import util.Threads;
 
-// -i /Users/preibischs/Documents/BIMSB/Publications/imglib2-st/slide-seq/raw/slide-seq.n5 -d1 Puck_180531_22.n5 -d2 Puck_180531_23.n5 -n 4 -sk 2
-// -i /Users/preibischs/Documents/BIMSB/Publications/imglib2-st/slide-seq/raw/slide-seq.n5 -d1 Puck_180602_15.n5 -d2 Puck_180602_16.n5 -n 4 -sk 2
-// -i visium.n5 -d1 slice1.h5ad -d2 slice2.n5 -n 9 -sk 14
+// -c /Users/preibischs/Documents/BIMSB/Publications/imglib2-st/slide-seq/raw/slide-seq.n5 -d1 Puck_180531_22.n5 -d2 Puck_180531_23.n5 -n 4 -sk 2
+// -c /Users/preibischs/Documents/BIMSB/Publications/imglib2-st/slide-seq/raw/slide-seq.n5 -d1 Puck_180602_15.n5 -d2 Puck_180602_16.n5 -n 4 -sk 2
+// -c visium.n5 -d1 slice1.h5ad -d2 slice2.n5 -n 9 -sk 14
 
 // align all
-//-i /Users/preibischs/Documents/BIMSB/Publications/imglib2-st/slide-seq/raw/slide-seq.n5 -d1 Puck_180528_22.n5 -d2 Puck_180528_20.n5 -n 4 -sk 2 // huge shift
-//-i /Users/preibischs/Documents/BIMSB/Publications/imglib2-st/slide-seq/raw/slide-seq.n5 -d1 Puck_180531_13.n5 -d2 Puck_180528_22.n5 -n 4 -sk 2
-//-i /Users/preibischs/Documents/BIMSB/Publications/imglib2-st/slide-seq/raw/slide-seq.n5 -d1 Puck_180531_17.n5 -d2 Puck_180531_13.n5 -n 4 -sk 2
-//-i /Users/preibischs/Documents/BIMSB/Publications/imglib2-st/slide-seq/raw/slide-seq.n5 -d1 Puck_180531_18.n5 -d2 Puck_180531_17.n5 -n 4 -sk 2
-//-i /Users/preibischs/Documents/BIMSB/Publications/imglib2-st/slide-seq/raw/slide-seq.n5 -d1 Puck_180531_19.n5 -d2 Puck_180531_18.n5 -n 4 -sk 2 --ffSingleSpot 1.5
-//-i /Users/preibischs/Documents/BIMSB/Publications/imglib2-st/slide-seq/raw/slide-seq.n5 -d1 Puck_180531_22.n5 -d2 Puck_180531_19.n5 -n 8 -sk 2 --ffSingleSpot 1.5
-//-i /Users/preibischs/Documents/BIMSB/Publications/imglib2-st/slide-seq/raw/slide-seq.n5 -d1 Puck_180531_23.n5 -d2 Puck_180531_22.n5 -n 8 -sk 2 --ffSingleSpot 1.5
-//-i /Users/preibischs/Documents/BIMSB/Publications/imglib2-st/slide-seq/raw/slide-seq.n5 -d1 Puck_180602_15.n5 -d2 Puck_180531_23.n5 -n 8 -sk 2 --ffSingleSpot 1.5
-//-i /Users/preibischs/Documents/BIMSB/Publications/imglib2-st/slide-seq/raw/slide-seq.n5 -d1 Puck_180602_16.n5 -d2 Puck_180602_15.n5 -n 8 -sk 2 --ffSingleSpot 1.5
-//-i /Users/preibischs/Documents/BIMSB/Publications/imglib2-st/slide-seq/raw/slide-seq.n5 -d1 Puck_180602_17.n5 -d2 Puck_180602_16.n5 -n 8 -sk 2 --ffSingleSpot 1.5
-//-i /Users/preibischs/Documents/BIMSB/Publications/imglib2-st/slide-seq/raw/slide-seq.n5 -d1 Puck_180602_18.n5 -d2 Puck_180602_17.n5 -n 8 -sk 2 --ffSingleSpot 1.5
-//-i /Users/preibischs/Documents/BIMSB/Publications/imglib2-st/slide-seq/raw/slide-seq.n5 -d1 Puck_180602_20.n5 -d2 Puck_180602_18.n5 -n 8 -sk 2 --ffSingleSpot 1.5
+//-c /Users/preibischs/Documents/BIMSB/Publications/imglib2-st/slide-seq/raw/slide-seq.n5 -d1 Puck_180528_22.n5 -d2 Puck_180528_20.n5 -n 4 -sk 2 // huge shift
+//-c /Users/preibischs/Documents/BIMSB/Publications/imglib2-st/slide-seq/raw/slide-seq.n5 -d1 Puck_180531_13.n5 -d2 Puck_180528_22.n5 -n 4 -sk 2
+//-c /Users/preibischs/Documents/BIMSB/Publications/imglib2-st/slide-seq/raw/slide-seq.n5 -d1 Puck_180531_17.n5 -d2 Puck_180531_13.n5 -n 4 -sk 2
+//-c /Users/preibischs/Documents/BIMSB/Publications/imglib2-st/slide-seq/raw/slide-seq.n5 -d1 Puck_180531_18.n5 -d2 Puck_180531_17.n5 -n 4 -sk 2
+//-c /Users/preibischs/Documents/BIMSB/Publications/imglib2-st/slide-seq/raw/slide-seq.n5 -d1 Puck_180531_19.n5 -d2 Puck_180531_18.n5 -n 4 -sk 2 --ffSingleSpot 1.5
+//-c /Users/preibischs/Documents/BIMSB/Publications/imglib2-st/slide-seq/raw/slide-seq.n5 -d1 Puck_180531_22.n5 -d2 Puck_180531_19.n5 -n 8 -sk 2 --ffSingleSpot 1.5
+//-c /Users/preibischs/Documents/BIMSB/Publications/imglib2-st/slide-seq/raw/slide-seq.n5 -d1 Puck_180531_23.n5 -d2 Puck_180531_22.n5 -n 8 -sk 2 --ffSingleSpot 1.5
+//-c /Users/preibischs/Documents/BIMSB/Publications/imglib2-st/slide-seq/raw/slide-seq.n5 -d1 Puck_180602_15.n5 -d2 Puck_180531_23.n5 -n 8 -sk 2 --ffSingleSpot 1.5
+//-c /Users/preibischs/Documents/BIMSB/Publications/imglib2-st/slide-seq/raw/slide-seq.n5 -d1 Puck_180602_16.n5 -d2 Puck_180602_15.n5 -n 8 -sk 2 --ffSingleSpot 1.5
+//-c /Users/preibischs/Documents/BIMSB/Publications/imglib2-st/slide-seq/raw/slide-seq.n5 -d1 Puck_180602_17.n5 -d2 Puck_180602_16.n5 -n 8 -sk 2 --ffSingleSpot 1.5
+//-c /Users/preibischs/Documents/BIMSB/Publications/imglib2-st/slide-seq/raw/slide-seq.n5 -d1 Puck_180602_18.n5 -d2 Puck_180602_17.n5 -n 8 -sk 2 --ffSingleSpot 1.5
+//-c /Users/preibischs/Documents/BIMSB/Publications/imglib2-st/slide-seq/raw/slide-seq.n5 -d1 Puck_180602_20.n5 -d2 Puck_180602_18.n5 -n 8 -sk 2 --ffSingleSpot 1.5
 public class InteractiveAlignment implements Callable<Void> {
 
-	@Option(names = {"-c", "--container"}, required = true, description = "input N5 container path, e.g. -i /home/ssq.n5.")
+	@Option(names = {"-c", "--container"}, required = true, description = "input N5 container path, e.g. -c /home/ssq.n5.")
 	private String inputPath = null;
 
 	@Option(names = {"-d1", "--dataset1"}, required = false, description = "the first dataset (slice), e.g. -d1 'Puck_180528_20'")

--- a/src/main/java/cmd/InteractiveAlignment.java
+++ b/src/main/java/cmd/InteractiveAlignment.java
@@ -60,7 +60,7 @@ import util.Threads;
 //-i /Users/preibischs/Documents/BIMSB/Publications/imglib2-st/slide-seq/raw/slide-seq.n5 -d1 Puck_180602_20.n5 -d2 Puck_180602_18.n5 -n 8 -sk 2 --ffSingleSpot 1.5
 public class InteractiveAlignment implements Callable<Void> {
 
-	@Option(names = {"-i", "--input"}, required = true, description = "input N5 container path, e.g. -i /home/ssq.n5.")
+	@Option(names = {"-c", "--container"}, required = true, description = "input N5 container path, e.g. -i /home/ssq.n5.")
 	private String inputPath = null;
 
 	@Option(names = {"-d1", "--dataset1"}, required = false, description = "the first dataset (slice), e.g. -d1 'Puck_180528_20'")

--- a/src/main/java/cmd/PairwiseSectionAligner.java
+++ b/src/main/java/cmd/PairwiseSectionAligner.java
@@ -35,7 +35,7 @@ import util.Threads;
 @Command(name = "st-align-pairs", mixinStandardHelpOptions = true, version = "0.3.0", description = "Spatial Transcriptomics as IMages project - align pairs of slices")
 public class PairwiseSectionAligner implements Callable<Void> {
 
-	@Option(names = {"-i", "--input"}, required = true, description = "input N5 container path, e.g. -i /home/ssq.n5.")
+	@Option(names = {"-c", "--container"}, required = true, description = "input N5 container path, e.g. -i /home/ssq.n5.")
 	private String containerPath = null;
 
 	@Option(names = {"-d", "--datasets"}, required = false, description = "ordered, comma separated list of one or more datasets, e.g. -d 'Puck_180528_20,Puck_180528_22' (default: all, in order as saved in N5 metadata)")

--- a/src/main/java/cmd/PairwiseSectionAligner.java
+++ b/src/main/java/cmd/PairwiseSectionAligner.java
@@ -35,7 +35,7 @@ import util.Threads;
 @Command(name = "st-align-pairs", mixinStandardHelpOptions = true, version = "0.3.0", description = "Spatial Transcriptomics as IMages project - align pairs of slices")
 public class PairwiseSectionAligner implements Callable<Void> {
 
-	@Option(names = {"-c", "--container"}, required = true, description = "input N5 container path, e.g. -i /home/ssq.n5.")
+	@Option(names = {"-c", "--container"}, required = true, description = "input N5 container path, e.g. -c /home/ssq.n5.")
 	private String containerPath = null;
 
 	@Option(names = {"-d", "--datasets"}, required = false, description = "ordered, comma separated list of one or more datasets, e.g. -d 'Puck_180528_20,Puck_180528_22' (default: all, in order as saved in N5 metadata)")
@@ -101,7 +101,7 @@ public class PairwiseSectionAligner implements Callable<Void> {
 	@Option(names = {"--hidePairwiseRendering"}, required = false, description = "do not show pairwise renderings that apply the 2D rigid models (default: false - showing them)")
 	private boolean hidePairwiseRendering = false;
 
-	//-i /Users/spreibi/Documents/BIMSB/Publications/imglib2-st/slide-seq-test.n5 -d 'Puck_180602_20,Puck_180602_18,Puck_180602_17,Puck_180602_16,Puck_180602_15,Puck_180531_23,Puck_180531_22,Puck_180531_19,Puck_180531_18,Puck_180531_17,Puck_180531_13,Puck_180528_22,Puck_180528_20' -n 100 --overwrite
+	//-c /Users/spreibi/Documents/BIMSB/Publications/imglib2-st/slide-seq-test.n5 -d 'Puck_180602_20,Puck_180602_18,Puck_180602_17,Puck_180602_16,Puck_180602_15,Puck_180531_23,Puck_180531_22,Puck_180531_19,Puck_180531_18,Puck_180531_17,Puck_180531_13,Puck_180528_22,Puck_180528_20' -n 100 --overwrite
 
 	@Override
 	public Void call() throws Exception {
@@ -255,8 +255,8 @@ public class PairwiseSectionAligner implements Callable<Void> {
 
 				long time = System.currentTimeMillis();
 
-				// hard case: -i /Users/spreibi/Documents/BIMSB/Publications/imglib2-st/slide-seq-test.n5 -d1 Puck_180602_15 -d2 Puck_180602_16 -n 30
-				// even harder: -i /Users/spreibi/Documents/BIMSB/Publications/imglib2-st/slide-seq-test.n5 -d1 Puck_180602_20 -d2 Puck_180602_18 -n 100 --overwrite
+				// hard case: -c /Users/spreibi/Documents/BIMSB/Publications/imglib2-st/slide-seq-test.n5 -d1 Puck_180602_15 -d2 Puck_180602_16 -n 30
+				// even harder: -c /Users/spreibi/Documents/BIMSB/Publications/imglib2-st/slide-seq-test.n5 -d1 Puck_180602_20 -d2 Puck_180602_18 -n 100 --overwrite
 				SiftMatch match = PairwiseSIFT.pairwiseSIFT(
 						stData1, t1, dataset1, stData2, t2, dataset2,
 						new RigidModel2D(), new RigidModel2D(),

--- a/src/main/java/cmd/RenderImage.java
+++ b/src/main/java/cmd/RenderImage.java
@@ -56,7 +56,7 @@ import render.Render;
 public class RenderImage implements Callable<Void> {
 
 	// st-render -i /Users/preibischs/Documents/BIMSB/Publications/imglib2-st/slide-seq/raw/slide-seq.n5 -d Puck_180531_22.n5,Puck_180531_23.n5 -g Malat1
-	// -dm Gauss -bMin 0.0 -bMax 0.1579 -sf 2.0922  --ffSingleSpot 1.25 --scale 0.10557775847089489
+	// -dm Gauss -bMin 0.0 -bMax 0.1579 -rf 2.0922  --ffSingleSpot 1.25 --scale 0.10557775847089489
 	@Option(names = {"-i", "--input"}, required = true, description = "input file or N5 container path, e.g. -i /home/ssq.n5.")
 	private String inputPath = null;
 

--- a/src/main/java/cmd/ViewPairwiseAlignment.java
+++ b/src/main/java/cmd/ViewPairwiseAlignment.java
@@ -39,8 +39,8 @@ public class ViewPairwiseAlignment implements Callable<Void> {
 	@Option(names = {"-s", "--scale"}, required = false, description = "scaling factor rendering the coordinates into images, which highly sample-dependent (default: 0.05 for slideseq data)")
 	private double scale = 0.05;
 
-	@Option(names = {"-sf", "--smoothnessFactor"}, required = false, description = "factor for the sigma of the gaussian used for rendering, corresponds to smoothness, e.g -sf 2.0 (default: 4.0)")
-	private double smoothnessFactor = 4.0;
+	@Option(names = {"-rf", "--renderingFactor"}, required = false, description = "factor for the amount of filtering or radius used for rendering, corresponds to smoothness for Gauss, e.g -rf 2.0 (default: 1.0)")
+	private double smoothnessFactor = 1.0;
 
 	@Option(names = {"-l", "--lambda"}, required = false, description = "for rendering we use a 2D interpolated model (affine/rigid). The number defines the degree of rigidity, fully affine is 0.0, fully rigid is 1.0 (default: 1.0 - rigid)")
 	private double model = 1.0;


### PR DESCRIPTION
There are some arguments that are inconsistent between commands, namely:

- `-c [--container]`
- `-rf [--renderingFactor]`

In some commands, these were the old `-i` and `-sf`. I propose to harmonize for user-friendliness