### PR TITLE
point st-bdv-view(3d) to correct classes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -80,7 +80,8 @@ install_command () {
 
 install_command st-explorer "cmd.View"
 install_command st-render "cmd.RenderImage"
-install_command st-bdv-view "cmd.DisplayStackedSlides"
+install_command st-bdv-view "cmd.BigDataViewerDisplay"
+install_command st-bdv-view3d "cmd.BigDataViewerStackDisplay"
 install_command st-resave "cmd.Resave"
 install_command st-add-slice "cmd.AddSlice"
 install_command st-normalize "cmd.Normalize"
@@ -92,6 +93,8 @@ install_command st-align-global "cmd.GlobalOpt"
 install_command st-align-interactive "cmd.InteractiveAlignment"
 install_command st-help "cmd.PrintHelp"
 
+install_command st-test-stdev "cmd.ComputeVariance"
+
 if [ $(pwd) == "${INSTALL_DIR}" ]; then
     echo "Installation directory equals current directory, we are done."
 else
@@ -99,6 +102,7 @@ else
     mkdir -p ${INSTALL_DIR}
     mv st-explorer ${INSTALL_DIR}/
     mv st-bdv-view ${INSTALL_DIR}/
+    mv st-bdv-view3d ${INSTALL_DIR}/
     mv st-render ${INSTALL_DIR}/
     mv st-resave ${INSTALL_DIR}/
     mv st-add-slice ${INSTALL_DIR}/
@@ -110,6 +114,7 @@ else
     mv st-align-global ${INSTALL_DIR}/
     mv st-align-interactive ${INSTALL_DIR}/
     mv st-help ${INSTALL_DIR}/
+    mv st-test-stdev ${INSTALL_DIR}/
 fi
 
 rm cp.txt

--- a/install_windows.bat
+++ b/install_windows.bat
@@ -48,7 +48,8 @@ call mvn -Dmdep.outputFile=cp.txt -Dmdep.includeScope=runtime -Dmaven.repo.local
 
 call :install_command st-explorer.bat cmd.View
 call :install_command st-render.bat cmd.RenderImage
-call :install_command st-bdv-view.bat cmd.DisplayStackedSlides
+call :install_command st-bdv-view.bat cmd.BigDataViewerDisplay
+call :install_command st-bdv-view3d.bat cmd.BigDataViewerStackDisplay
 call :install_command st-resave.bat cmd.Resave
 call :install_command st-add-slice.bat cmd.AddSlice
 call :install_command st-normalize.bat cmd.Normalize
@@ -66,6 +67,7 @@ if "%CD%"=="%INSTALL_DIR%" (
    	mkdir "%INSTALL_DIR%"
    	move "st-explorer.bat" "%INSTALL_DIR%\"
 	move "st-bdv-view.bat" "%INSTALL_DIR%\"
+	move "st-bdv-view3d.bat" "%INSTALL_DIR%\"
 	move "st-render.bat" "%INSTALL_DIR%\"
    	move "st-resave.bat" "%INSTALL_DIR%\"
 	move "st-add-slice.bat" "%INSTALL_DIR%\"


### PR DESCRIPTION
The command `st-bdv-view` is pointing to the old `cmd.DisplayStackedSlides`. This is fixed here (also for `st-bdv-view3d`).